### PR TITLE
Changed the default mocha test name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ This generator will install the following files:
 * LICENSE - BSD-3-Clause initialized with your details.
 * README.md - Initialized with your details and travis-ci badges.
 * index.js - Initial library file
-* test/index.js - First mocha unit test
+* test/index.spec.js - First mocha unit test
 

--- a/app/index.js
+++ b/app/index.js
@@ -62,7 +62,7 @@ NodejsGenerator.prototype.askFor = function askFor() {
       name: 'author',
       message: 'Author name',
       default:
-        ((config.user && config.user.name) || '') + 
+        ((config.user && config.user.name) || '') +
         (' <' + ((config.user && config.user.email) || '') + '>')
     }
   ];
@@ -98,5 +98,5 @@ NodejsGenerator.prototype.mocha = function mocha() {
   this.mkdir('test');
   this.mkdir('test/fixtures');
   this.copy('lib.js', 'index.js');
-  this.template('test.js', 'test/index.js');
+  this.template('test.js', 'test/index.spec.js');
 };

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
       }
     },
     mochacli: {
-      all: ['test/**/*.js'],
+      spec: ['test/**/*.spec.js'],
       options: {
         reporter: 'spec',
         ui: 'tdd'

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -18,15 +18,15 @@ describe('nodejs generator', function () {
     }.bind(this));
   });
 
-  it('creates expected files', function (done) {
+  it('should create expected files', function (done) {
     var expected = [
       'index.js',
-      'test/index.js',
+      'test/index.spec.js',
       '.gitignore',
       '.jshintrc',
       '.travis.yml',
       ['package.json', /"name": "mymodule"/],
-      ['Gruntfile.js', /!node_modules/],
+      'Gruntfile.js',
       'README.md',
       'LICENSE'
     ];
@@ -39,8 +39,34 @@ describe('nodejs generator', function () {
       'author': 'Octo Cat <main@mail.com>'
     });
 
+    // Lets not install dependencies in test
+    this.app.options['skip-install'] = true;
     this.app.run({}, function () {
       helpers.assertFiles(expected);
+      done();
+    });
+  });
+
+  it('should create valid gruntfile', function (done) {
+    var rules = [
+      /!node_modules/,
+      /spec: \['test\/\*\*\/\*\.spec\.js'\]/
+    ];
+
+    helpers.mockPrompt(this.app, {
+      'moduleName': 'mymodule',
+      'moduleDesc': 'awesome module',
+      'keywords': 'something',
+      'githubName': 'octocat',
+      'author': 'Octo Cat <main@mail.com>'
+    });
+
+    // Lets not install dependencies in test
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      rules.forEach(function(rule) {
+        helpers.assertFile('Gruntfile.js', rule);
+      });
       done();
     });
   });


### PR DESCRIPTION
Changed the mocha test name from test.js to test.spec.js.

Normally webapps have two different test suites. One suit for spec tests and one for integration tests. 
So I took the liberty of renaming the default test as spec test and adding a mocha-cli spec job. This makes it easier to add integration tests in the long run.

Also removed that bloody annoying automatic dependency installment for tests. :)
