### PR TITLE
Work with keywords passed as array.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -42,7 +42,10 @@ NodejsGenerator.prototype.askFor = function askFor() {
       message: 'Module keywords',
       filter:
         function (value) {
-          return value.split(',')
+          if (typeof value === 'string') {
+            value = value.split(',');
+          };
+          return value
             .map(function (val) {
               return val.trim();
             })


### PR DESCRIPTION
It seems that Yeoman started to process keywords by itself. For this cases we parse keywords only if string given.
