### PR TITLE
User may specify package names for dependencies and devDependencies as c...

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -87,7 +87,43 @@ NodejsGenerator.prototype.askFor = function askFor() {
       default:
         ((config.user && config.user.name) || '') + 
         (' <' + ((config.user && config.user.email) || '') + '>')
-    }
+    },
+    {
+      type: 'input',
+      name: 'dependencies',
+      message: 'Package Dependencies (comma-separated)',
+      filter:
+        function (value) {
+          if (typeof value === 'string') {
+            value = value.split(',');
+          }
+          return value
+            .map(function (val) {
+              return val.trim();
+            })
+            .filter(function (val) {
+              return val.length > 0;
+            })
+        }
+    },    
+    {
+      type: 'input',
+      name: 'devDependencies',
+      message: 'Dev Dependencies (comma-separated)',
+      filter:
+        function (value) {
+          if (typeof value === 'string') {
+            value = value.split(',');
+          }
+          return value
+            .map(function (val) {
+              return val.trim();
+            })
+            .filter(function (val) {
+              return val.length > 0;
+            })
+        }
+    }    
   ];
 
   this.prompt(prompts, function (props) {
@@ -101,6 +137,8 @@ NodejsGenerator.prototype.askFor = function askFor() {
     this.testFramework = props.testFramework;
     this.assertionLibrary = props.assertionLibrary;
     this.useGrunt = props.useGrunt;
+    this.dependencies = props.dependencies;
+    this.devDependencies = props.devDependencies;
 
     this.dequote = function (str) {
       return str.replace(/\"/gm, '\\"');

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -31,9 +31,22 @@
   "bugs": {
     "url": "https://github.com/<%= githubName %>/<%= moduleName %>/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+<%
+      var lastItem = dependencies.length - 1;
+      for (i = 0; i < dependencies.length ; i++){
+        if( i === lastItem){
+          print('    "' + dependencies[i] + '": "*"')
+        } else {
+          print('    "' + dependencies[i] + '": "*",\n')
+        }
+      }%>
+    },
   "devDependencies": {
 <%
+    devDependencies.forEach(function(item){
+      print('    "' + item + '": "*",\n')
+    });
     switch (assertionLibrary) {
       case 'expect.js':
         print('    "expect.js": "~0.2.0",');

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -40,7 +40,9 @@ describe('nodejs generator', function () {
       'testFramework': 'mocha',
       'assertionLibrary': 'expect.js',
       'githubName': 'octocat',
-      'author': 'Octo Cat <main@mail.com>'
+      'author': 'Octo Cat <main@mail.com>',
+	  'dependencies': ['express','underscore'],
+      'devDependencies': ['should','validator']
     });
 
     this.app.run({}, function () {
@@ -74,7 +76,9 @@ describe('nodejs generator', function () {
       'testFramework': 'tape',
       'assertionLibrary': 'none',
       'githubName': 'octocat',
-      'author': 'Octo Cat <main@mail.com>'
+      'author': 'Octo Cat <main@mail.com>',
+	  'dependencies': ['express','underscore'],
+      'devDependencies': ['should','validator']
     });
 
     this.app.run({}, function () {


### PR DESCRIPTION
...omma-separated values. Lastest versions are added.

Sometimes you know ahead of time what packages you are going to need. It might be convenient to allow the user to specify dependencies or devDependencies when the package is being created (in addition to Grunt and test frameworks).
